### PR TITLE
add missing set_model_mode

### DIFF
--- a/R/parsnip-garch_multivariate_reg_data.R
+++ b/R/parsnip-garch_multivariate_reg_data.R
@@ -2,6 +2,7 @@
 
 make_garch_multi_reg <- function() {
     parsnip::set_new_model("garch_multivariate_reg")
+    parsnip::set_model_mode("garch_reg", "regression")
 }
 
 

--- a/R/parsnip-garch_multivariate_reg_data.R
+++ b/R/parsnip-garch_multivariate_reg_data.R
@@ -2,7 +2,7 @@
 
 make_garch_multi_reg <- function() {
     parsnip::set_new_model("garch_multivariate_reg")
-    parsnip::set_model_mode("garch_reg", "regression")
+    parsnip::set_model_mode("garch_multivariate_reg", "regression")
 }
 
 

--- a/R/parsnip-garch_reg_data.R
+++ b/R/parsnip-garch_reg_data.R
@@ -2,6 +2,7 @@
 
 make_garch_reg <- function() {
     parsnip::set_new_model("garch_reg")
+    parsnip::set_model_mode("garch_reg", "regression")
 }
 
 


### PR DESCRIPTION
Hello @AlbertoAlmuinha 👋

We are wrapping up for another CRAN release for {parsnip} soon. I noticed in the reverse dependency check that a set_model_mode() is missing.

You don't need to wait for us to update {parsnip} on CRAN before you can update {garchmodels}.